### PR TITLE
Add virtual torque blending for Tesla 3/Y

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -208,6 +208,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"UpdaterTargetBranch", CLEAR_ON_MANAGER_START},
     {"UpdaterLastFetchTime", PERSISTENT},
     {"Version", PERSISTENT},
+    {"VirtualTorqueBlending", PERSISTENT},
 
     // FrogPilot parameters
     {"AccelerationPath", PERSISTENT | FROGPILOT_STORAGE | FROGPILOT_VISUALS},

--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -6,11 +6,28 @@ from openpilot.selfdrive.car.tesla.teslacan import TeslaCAN
 from openpilot.selfdrive.car.tesla.values import DBC, CarControllerParams
 
 
+def torque_blended_angle(apply_angle, torsion_bar_torque):
+  deadzone = CarControllerParams.TORQUE_TO_ANGLE_DEADZONE
+  if abs(torsion_bar_torque) < deadzone:
+    return apply_angle
+
+  limit = CarControllerParams.TORQUE_TO_ANGLE_CLIP
+  if apply_angle * torsion_bar_torque >= 0:
+    # Manually steering in the same direction as OP
+    strength = CarControllerParams.TORQUE_TO_ANGLE_MULTIPLIER_OUTER
+  else:
+    # User is opposing OP direction
+    strength = CarControllerParams.TORQUE_TO_ANGLE_MULTIPLIER_INNER
+
+  torque = torsion_bar_torque - deadzone if torsion_bar_torque > 0 else torsion_bar_torque + deadzone
+  return apply_angle + clip(torque, -limit, limit) * strength
+
 class CarController(CarControllerBase):
   def __init__(self, dbc_name, CP, VM):
     self.CP = CP
     self.frame = 0
     self.apply_angle_last = 0
+    self.last_hands_nanos = 0
     self.packer = CANPacker(dbc_name)
     self.pt_packer = CANPacker(DBC[CP.carFingerprint]['pt'])
     self.tesla_can = TeslaCAN(self.packer, self.pt_packer)
@@ -21,14 +38,32 @@ class CarController(CarControllerBase):
 
     can_sends = []
 
-    # Temp disable steering on a hands_on_fault, and allow for user override
-    hands_on_fault = CS.steer_warning == "EAC_ERROR_HANDS_ON" and CS.hands_on_level >= 3
-    lkas_enabled = CC.latActive and not hands_on_fault
-
     if self.frame % 2 == 0:
+      # Detect a user override of the steering wheel when...
+      CS.steering_override = (CS.hands_on_level >= 3 or  # user is applying lots of force or...
+        (CS.steering_override and  # already overriding and...
+         abs(CS.out.steeringAngleDeg - actuators.steeringAngleDeg) > CarControllerParams.CONTINUED_OVERRIDE_ANGLE) and
+         not CS.out.standstill)  # continued angular disagreement while moving.
+
+      # If fully hands off for 1 second then reset override (in case of continued disagreement above)
+      if CS.hands_on_level > 0:
+        self.last_hands_nanos = now_nanos
+      elif now_nanos - self.last_hands_nanos > 1e9:
+        CS.steering_override = False
+
+      # Reset override when disengaged to ensure a fresh activation always engages steering.
+      if not CC.latActive:
+        CS.steering_override = False
+
+      # Temporarily disable LKAS if user is overriding or if OP lat isn't active
+      lkas_enabled = CC.latActive and not CS.steering_override
+
       if lkas_enabled:
+        # Update steering angle request with user input torque
+        apply_angle = torque_blended_angle(actuators.steeringAngleDeg, CS.out.steeringTorque)
+
         # Angular rate limit based on speed
-        apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
+        apply_angle = apply_std_steer_angle_limits(apply_angle, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
 
         # To not fault the EPS
         apply_angle = clip(apply_angle, CS.out.steeringAngleDeg - 20, CS.out.steeringAngleDeg + 20)
@@ -48,10 +83,6 @@ class CarController(CarControllerBase):
 
       counter = CS.das_control["DAS_controlCounter"]
       can_sends.append(self.tesla_can.create_longitudinal_commands(acc_state, target_speed, min_accel, max_accel, counter))
-
-    # Cancel on user steering override, since there is no steering torque blending
-    if hands_on_fault:
-      pcm_cancel_cmd = True
 
     # Sent cancel request only if ACC is enabled
     if self.frame % 10 == 0 and pcm_cancel_cmd and CS.acc_enabled:

--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -1,4 +1,5 @@
 from openpilot.common.numpy_fast import clip
+from openpilot.common.params import Params
 from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import apply_std_steer_angle_limits
 from openpilot.selfdrive.car.interfaces import CarControllerBase
@@ -31,6 +32,7 @@ class CarController(CarControllerBase):
     self.packer = CANPacker(dbc_name)
     self.pt_packer = CANPacker(DBC[CP.carFingerprint]['pt'])
     self.tesla_can = TeslaCAN(self.packer, self.pt_packer)
+    self.virtual_blending = Params().get_bool("VirtualTorqueBlending")
 
   def update(self, CC, CS, now_nanos, frogpilot_variables):
     actuators = CC.actuators
@@ -59,8 +61,11 @@ class CarController(CarControllerBase):
       lkas_enabled = CC.latActive and not CS.steering_override
 
       if lkas_enabled:
-        # Update steering angle request with user input torque
-        apply_angle = torque_blended_angle(actuators.steeringAngleDeg, CS.out.steeringTorque)
+        if self.virtual_blending:
+          # Update steering angle request with user input torque
+          apply_angle = torque_blended_angle(actuators.steeringAngleDeg, CS.out.steeringTorque)
+        else:
+          apply_angle = actuators.steeringAngleDeg
 
         # Angular rate limit based on speed
         apply_angle = apply_std_steer_angle_limits(apply_angle, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
@@ -83,6 +88,11 @@ class CarController(CarControllerBase):
 
       counter = CS.das_control["DAS_controlCounter"]
       can_sends.append(self.tesla_can.create_longitudinal_commands(acc_state, target_speed, min_accel, max_accel, counter))
+
+    if not self.virtual_blending:
+      # Cancel on user steering override when blending is disabled
+      if CS.steering_override:
+        pcm_cancel_cmd = True
 
     # Sent cancel request only if ACC is enabled
     if self.frame % 10 == 0 and pcm_cancel_cmd and CS.acc_enabled:

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -18,6 +18,7 @@ class CarState(CarStateBase):
     self.acc_enabled = None
     self.sccm_right_stalk_counter = None
     self.das_control = None
+    self.steering_override = False  # Set in CC because actuator info is needed to determine this.
 
   def update(self, cp, cp_cam, cp_adas, frogpilot_variables):
     ret = car.CarState.new_message()
@@ -45,7 +46,7 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = -cp_adas.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
     ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]
 
-    ret.steeringPressed = (self.hands_on_level > 0)
+    ret.steeringPressed = (self.hands_on_level > 0 or self.steering_override or self.update_steering_pressed(abs(ret.steeringTorque) > 1.0, 5))  # hands_on_level has too much filtering
     ret.steerFaultPermanent = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None) in ["EAC_FAULT"]
     ret.steerFaultTemporary = (self.steer_warning not in ("EAC_ERROR_IDLE", "EAC_ERROR_HANDS_ON") and ret.steerFaultPermanent not in ["EAC_ACTIVE", "EAC_AVAILABLE"])
 

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -12,9 +12,9 @@ class CarInterface(CarInterfaceBase):
   def _get_params(ret, params, candidate, fingerprint, car_fw, disable_openpilot_long, experimental_long, docs):
     ret.carName = "tesla"
 
-    # There is no safe way to do steer blending with user torque,
-    # so the steering behaves like autopilot. This is not
-    # how openpilot should be, hence dashcamOnly
+    # Steer blending with user torque is done virtually, and is limited to 2Nm of torque
+    # before it temporarily disables OP Lat control for higher user torque. This is not
+    # how openpilot typically works, hence dashcamOnly
     ret.dashcamOnly = False
 
     ret.steerControlType = car.CarParams.SteerControlType.angle

--- a/selfdrive/car/tesla/values.py
+++ b/selfdrive/car/tesla/values.py
@@ -75,6 +75,11 @@ class CarControllerParams:
   JERK_LIMIT_MAX = 8
   JERK_LIMIT_MIN = -8
   ACCEL_TO_SPEED_MULTIPLIER = 3
+  TORQUE_TO_ANGLE_MULTIPLIER_OUTER = 4  # Higher = easier to influence when manually steering more than OP
+  TORQUE_TO_ANGLE_MULTIPLIER_INNER = 8  # Higher = easier to influence when manually steering less than OP
+  TORQUE_TO_ANGLE_DEADZONE = 0.5  # This equates to hands-on level 1, so we don't allow override if not hands-on
+  TORQUE_TO_ANGLE_CLIP = 10. # Steering (usually) disengages at 2.5 Nm, this limit exists only in case the EPAS gives bad data
+  CONTINUED_OVERRIDE_ANGLE = 10.  # The angle difference between OP and user to continue overriding steering (prevents oscillation)
 
   def __init__(self, CP):
     pass

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -316,6 +316,7 @@ def manager_init(frogpilot_functions) -> None:
 
     # Tesla specific parameters
     ("StockTaccEnabledToggle", "0"),
+    ("VirtualTorqueBlending", "0"),
   ]
   if not PC:
     default_params.append(("LastUpdateTime", datetime.datetime.utcnow().isoformat().encode('utf8')))

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -62,6 +62,12 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       "../assets/offroad/icon_speed_limit.png",
     },
     {
+      "VirtualTorqueBlending",
+      tr("Virtual Torque Blending"),
+      tr("Allow for nudging the steering while openpilot is engaged."),
+      "../assets/offroad/icon_openpilot.png",
+    },
+    {
       "DisengageOnAccelerator",
       tr("Disengage on Accelerator Pedal"),
       tr("When enabled, pressing the accelerator pedal will disengage openpilot."),


### PR DESCRIPTION
This adds virtual torque blending to the frogtesla port.

**Routes:**
With blending disabled: `bbbf82d987d681bc/0000012e--0007f5c894`
With blending enabled: `bbbf82d987d681bc/0000012f--e601c6467f`

**TL;DR:** Enabling the Virtual Torque Blending toggle allows the user to steer while OP is engaged. It works by taking the user's steering torque and adjusts the angle output from OP before sending it to the car's EPAS, allowing the user to easily nudge the car within the lane, nudge it into exit ramps, and manually take turns, all without disengaging OP.

Torque blending strength can be tweaked by changing the multipliers in values.py, although keep in mind the latency and rate limit's effect on the strength's real-world effect, see below.

**Limitation:** The EPAS will not allow more than 2.5 Nm of torque from the user (except in very brief bursts) without faulting, in addition the control loop is a bit too slow to keep up with a fast manual steering jerk from the user. As a result, the virtual blending switches to a silent disengagement of lat control in some scenarios, automatically re-enabling lat control once the user's torque has decreased and the user's steering angle is again close to the OP commanded angle, or if more than 1 second elapses without user torque even if there is still an angular disagreement. This switchover from torque blending to full override sometimes results in feeling a bump in the steering, similar to the bump when disengaging from classic AP. Work is still being done to try to minimize the strength of this bump, it's typically felt when turning sharp corners at low speeds.

**Safety considerations:**
- Ability to always override: this is baked in to the Tesla's EPAS, it's always possible to override the steering with ~ 2.5 Nm of force no matter what OP tries to do.
- Never silently release control to the user without the user having hands on the wheel: the main criteria for silently disengaging is to reach hands-on-level 3, which is a signal from the EPAS that roughly equates to > 2.5 Nm of force (with some filtering)
- Avoid accidental torque blending: there is a 0.5 Nm deadzone where the angle is not modified, so that a misbalance of the wheel, or slight hand weight, will not cause it to veer from OP's lat control.
- Avoid high-rate steering even if data is faulty: the steering rate limiting is applied *after* the torque blending, so even if OP receives faulty torque data, the rate limits will still be respected, giving the user time to override.
- Blending is disabled by default behind a toggle to ensure the user is aware of the feature, reducing risk of accidental nudging from misunderstanding the capability.

As always, it's possible not all safety considerations were realized, or that an edge case was missed, use with caution.